### PR TITLE
Synopsys: Automated PR: Update org.hibernate:hibernate-core:5.3.0.Final to 5.6.15.Final

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ dependencies {
     api 'org.springframework:spring-web:4.2.3.RELEASE'
     api 'javax.servlet:jstl:1.2'
     api 'javax.validation:validation-api:1.0.0.GA'
-    api 'org.hibernate:hibernate-core:5.3.0.Final'
+    api 'org.hibernate:hibernate-core:5.6.15.Final'
     api 'com.jolbox:bonecp:0.8.0.RELEASE'
     api 'org.postgresql:postgresql:9.2-1004-jdbc4'
     api 'org.hsqldb:hsqldb:2.3.4'


### PR DESCRIPTION
## Vulnerabilities associated with org.hibernate:hibernate-core:5.3.0.Final
[BDSA-2020-3410](https://openhub.net/vulnerabilities/bdsa/BDSA-2020-3410) *(HIGH)*: Hibernate ORM is vulnerable to SQL injection due to the unsafe implementation of comments that are intended for debugging purposes. A remote attacker could potentially recover, modify or delete sensitive information that resides in back-end databases by submitting crafted requests that abuse these comments. It should be noted that only instances of Hibernate ORM that use a non-default configuration are affected.

[BDSA-2019-4479](https://openhub.net/vulnerabilities/bdsa/BDSA-2019-4479) *(MEDIUM)*: Hibernate ORM is vulnerable to SQL injection (SQLi) due to insufficient validation of user-controlled input. An attacker may be able to obtain unauthorized information from the database by executing arbitrary SQL commands.

[Click Here To See More Details On Server](https://testing.blackduck.synopsys.com/api/projects/4257d48f-dc01-4dc3-9829-88a4665fb644/versions/ff362ece-ecb7-402e-aa78-7b66c96630fe/vulnerability-bom?selectedItem=99ae5b84-6459-40fa-a42e-3d2baae81ed4)